### PR TITLE
feat: Support Miggo Projects

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -19,6 +19,7 @@ def handler(event, context):
         'RequestId': context.aws_request_id,
         'LogicalResourceId': event['LogicalResourceId'],
         'TenantId': os.environ.get('TENANT_ID'),
+        'ProjectId': os.environ.get('PROJECT_ID'),
         'TenantEmail': os.environ.get('TENANT_EMAIL')
     }
 

--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,13 @@ resource "aws_lambda_function" "pingback_lambda" {
 resource "aws_lambda_invocation" "pingback" {
   function_name = aws_lambda_function.pingback_lambda.function_name
 
+  triggers = {
+    tenant_id    = var.tenant_id
+    tenant_email = var.tenant_email
+    webhook_url  = var.webhook_url
+    project_id   = var.project_id
+  }
+
   input = jsonencode({
     StackId           = "terraform-stack"
     LogicalResourceId = "PingbackTerraformResource"

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ resource "aws_lambda_function" "pingback_lambda" {
   environment {
     variables = {
       TENANT_ID    = var.tenant_id
+      PROJECT_ID   = var.project_id
       TENANT_EMAIL = var.tenant_email
       WEBHOOK_URL  = var.webhook_url
     }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "tenant_id" {
   description = "Tenant ID"
 }
 
+variable "project_id" {
+  type        = string
+  description = "Project ID"
+}
+
 variable "tenant_email" {
   type        = string
   description = "Tenant Email"


### PR DESCRIPTION
#### Summary:
This update allows passing and using the `ProjectId` within the Lambda function and the Terraform setup, providing better project-level management and organization of resources.

#### Changes:
1. **Lambda Function (`lambda.py`)**
   - Added support for `ProjectId` in the Lambda handler to pass the project ID from the environment variables.
   
2. **Terraform Configuration (`main.tf`, `variables.tf`)**
   - Added `PROJECT_ID` to the Lambda function environment variables.
   - Defined the `project_id` variable in `variables.tf` to enable input from Terraform.

