### PR TITLE
Add organizations:DescribeAccount to AWS integration to add a name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "aws_iam_policy" "cluster_interaction_policy" {
       {
         Effect = "Allow"
         Action = [
+          "organizations:DescribeAccount",
           "ec2:Describe*",
           "eks:DescribeCluster",
           "eks:ListClusters",


### PR DESCRIPTION
To allow fetching of Account Name, as part of the AWS integration `organizations:DescribeAccount` permission is required and being added here.