### PR TITLE
fix: derive ExternalId from tenant_id instead of separate input [DO-426]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "cluster_interaction_role" {
         Action = "sts:AssumeRole"
         Condition = {
           StringEquals = {
-            "sts:ExternalId" = var.external_id
+            "sts:ExternalId" = upper(var.tenant_id)
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "external_id" {
-  type        = string
-  description = "External ID for the AssumeRole policy"
-}
-
 variable "tenant_id" {
   type        = string
   description = "Tenant ID"


### PR DESCRIPTION
## Summary
- Remove the `external_id` variable
- Compute `sts:ExternalId` in the trust policy as `upper(var.tenant_id)` instead

## Why
The backend (`aws_utils.py`) always calls `sts:AssumeRole` with `ExternalId = tenant_id.upper()`. Having a separate `external_id` input in the module was redundant and error-prone — customers who left it blank (or passed an empty string) ended up with a broken trust policy, causing every `AssumeRole` call to fail silently with `AccessDenied`. Workflows completed without error but skipped all data collection.

Since the value is always derived from the tenant ID, there's no reason to expose it as a configurable input.

## Test plan
- [ ] Apply the module with only `tenant_id`, `project_id`, `tenant_email`, `webhook_url`
- [ ] Verify `ClusterInteractionRole` trust policy has `sts:ExternalId` set to the uppercased tenant ID
- [ ] Verify `sts:AssumeRole` succeeds from the Temporal worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)