### PR TITLE
Revert "fix: derive ExternalId from tenant_id instead of separate input [DO-426]"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role" "cluster_interaction_role" {
         Action = "sts:AssumeRole"
         Condition = {
           StringEquals = {
-            "sts:ExternalId" = upper(var.tenant_id)
+            "sts:ExternalId" = var.external_id
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "external_id" {
+  type        = string
+  description = "External ID for the AssumeRole policy"
+}
+
 variable "tenant_id" {
   type        = string
   description = "Tenant ID"


### PR DESCRIPTION
Reverts miggo-io/terraform-aws-miggo-integration#5