### PR TITLE
feat: add tags support to all created resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_policy" "cluster_interaction_policy" {
   path        = "/"
   description = "Miggo read-only integration with AWS"
+  tags        = var.tags
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -57,6 +58,7 @@ resource "aws_iam_role" "cluster_interaction_role" {
 
   managed_policy_arns = [aws_iam_policy.cluster_interaction_policy.arn]
   description         = "Miggo read-only role"
+  tags                = var.tags
 }
 
 resource "aws_iam_role" "lambda_role" {
@@ -72,6 +74,7 @@ resource "aws_iam_role" "lambda_role" {
       }
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy" "lambda_policy" {
@@ -116,6 +119,8 @@ resource "aws_lambda_function" "pingback_lambda" {
       WEBHOOK_URL  = var.webhook_url
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_lambda_invocation" "pingback" {

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,9 @@ variable "webhook_url" {
   type        = string
   description = "Miggo Webhook URL"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all created resources"
+  default     = {}
+}


### PR DESCRIPTION
## Summary

Adds an optional `tags` input variable that propagates to all taggable resources created by this module.

**Changes:**
- New `tags` variable (`map(string)`, defaults to `{}`) in `variables.tf`
- `tags = var.tags` applied to `aws_iam_policy`, both `aws_iam_role` resources, and `aws_lambda_function`

Resources that do not support the `tags` argument (`aws_iam_role_policy`, `aws_lambda_invocation`) are unchanged.

## Usage

```hcl
module "miggo_integration" {
  source = "miggo-io/miggo-integration/aws"

  tenant_id    = "..."
  project_id   = "..."
  tenant_email = "..."
  webhook_url  = "..."

  tags = {
    Environment = "production"
    Team        = "platform"
  }
}
```

Callers that do not set `tags` are unaffected — the variable defaults to an empty map.