### PR TITLE
feat: add WAF read permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,14 +21,24 @@ resource "aws_iam_policy" "cluster_interaction_policy" {
           "elasticbeanstalk:Describe*",
           "lambda:List*",
           "lambda:Get*",
+          "apigateway:GET",
           "route53:List*",
           "route53:Get*",
           "waf:List*",
           "waf:Get*",
           "wafv2:List*",
           "wafv2:Get*",
+          "wafv2:CheckCapacity",
+          "fms:List*",
+          "fms:Get*",
+          "shield:Describe*",
+          "shield:Get*",
+          "shield:List*",
           "cloudfront:List*",
-          "cloudfront:Get*"
+          "cloudfront:Get*",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:ListMetrics",
+          "cloudwatch:GetMetricStatistics"
         ]
         Resource = "*"
       }


### PR DESCRIPTION
## Summary

Extends `aws_iam_policy.cluster_interaction_policy` in `main.tf` with the additional read permissions the Miggo backend now needs:

- `apigateway:GET`
- `wafv2:CheckCapacity`
- `fms:List*`, `fms:Get*`
- `shield:Describe*`, `shield:Get*`, `shield:List*`
- `cloudwatch:GetMetricData`, `cloudwatch:ListMetrics`, `cloudwatch:GetMetricStatistics`

New entries are placed by service family, preserving the existing ordering (e.g. `apigateway:GET` adjacent to `lambda`, `wafv2:CheckCapacity` next to other `wafv2:*`, `shield:*` and `fms:*` grouped with the WAF family, `cloudwatch:*` at the end as a distinct observability concern).

Relates to PIP-899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)