### PR TITLE
fix: upgrade Lambda runtime from python3.9 to python3.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "pingback_lambda" {
   function_name    = "MiggoPingbackLambdaFunction"
   role             = aws_iam_role.lambda_role.arn
   handler          = "lambda.handler"
-  runtime          = "python3.9"
+  runtime          = "python3.12"
   timeout          = 60
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
 


### PR DESCRIPTION
## Summary
- Upgrades the Miggo Pingback Lambda runtime from `python3.9` to `python3.12`
- Python 3.9 is being deprecated by AWS Lambda — new Lambda creation will be blocked
- The Lambda code (json, os, urllib3, boto3) is fully compatible with Python 3.12, no code changes needed

## Context
- Linear ticket: DAQ-93
- Affects both customer Terraform deployments and our internal infra deployments
- The CloudFormation template in `ui-modules/cfn.mdx` also needs updating (separate PR)

## Test plan
- [ ] Point `aws/playground/miggo-integration` in infra repo to this branch via git source
- [ ] Run `terragrunt apply` in playground
- [ ] Verify Lambda runtime is `python3.12`: `aws lambda get-function --function-name MiggoPingbackLambdaFunction --query 'Configuration.Runtime'`
- [ ] Verify pingback webhook succeeds (check CloudWatch logs + Miggo integrations pane)
- [ ] After validation, merge this PR, tag `v1.6.0`, and update infra repo to use new registry version

🤖 Generated with [Claude Code](https://claude.com/claude-code)